### PR TITLE
Fix wheel draw error

### DIFF
--- a/game.py
+++ b/game.py
@@ -130,7 +130,8 @@ def main():
 
         for wheel in (motor1.b, motor2.b):
             pos = to_pygame((wheel.position.x + offset_x, wheel.position.y))
-            pygame.draw.circle(screen, COLORS["wheel"], pos, int(wheel.shapes[0].radius), 0)
+            wheel_shape = next(iter(wheel.shapes))
+            pygame.draw.circle(screen, COLORS["wheel"], pos, int(wheel_shape.radius), 0)
 
         pygame.display.flip()
 


### PR DESCRIPTION
## Summary
- fix wheel radius retrieval when drawing wheels

## Testing
- `python -m py_compile game.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pygame)*